### PR TITLE
Check if a PR has been closed at start of run

### DIFF
--- a/rcmt/rcmt.py
+++ b/rcmt/rcmt.py
@@ -43,6 +43,15 @@ class RepoRun:
         pkgs: list[package.Package],
         repo: source.Repository,
     ):
+        pr_identifier = repo.find_pull_request(self.git.branch_name)
+        if pr_identifier is not None and repo.is_pr_closed(pr_identifier) is True:
+            log.info(
+                "Existing PR has been closed by the user",
+                branch=self.git.branch_name,
+                repo=str(repo),
+            )
+            return
+
         work_dir = self.git.prepare(repo)
         tpl_mapping = {"repo_name": repo.name, "repo_project": repo.project}
         pr = source.PullRequest(
@@ -83,15 +92,6 @@ class RepoRun:
             else:
                 log.debug("Pushing changes", repo=str(repo))
                 self.git.push(work_dir)
-
-        pr_identifier = repo.find_pull_request(self.git.branch_name)
-        if pr_identifier is not None and repo.is_pr_closed(pr_identifier) is True:
-            log.info(
-                "Existing PR has been closed by the user",
-                branch=self.git.branch_name,
-                repo=str(repo),
-            )
-            return
 
         if needs_push is True and (
             pr_identifier is None or repo.is_pr_merged(pr_identifier) is True

--- a/tests/test_rcmt.py
+++ b/tests/test_rcmt.py
@@ -178,13 +178,9 @@ class RunTest(unittest.TestCase):
 
         runner.execute(run, [pkg], repo_mock)
 
-        action_mock.apply.assert_called_once_with(
-            self.pkg_path,
-            "/unit/test",
-            {"repo_name": "myrepo", "repo_project": "myproject"},
-        )
+        action_mock.apply.assert_not_called()
         repo_mock.find_pull_request.assert_called_once_with("rcmt")
         repo_mock.is_pr_closed.assert_called_once_with("someid")
-        git_mock.push.assert_called_once_with("/unit/test")
+        git_mock.push.assert_not_called()
         repo_mock.create_pull_request.assert_not_called()
         repo_mock.merge_pull_request.assert_not_called()


### PR DESCRIPTION
Avoids unnecessary pull of repository and branches and saves bandwidth.