### PR TITLE
fix: git pull can fail if repository names overlap

### DIFF
--- a/rcmt/git.py
+++ b/rcmt/git.py
@@ -69,6 +69,7 @@ class Git:
             "Pulling changes into base branch", branch=repo.base_branch, repo=str(repo)
         )
         git_repo.remotes["origin"].pull()
+        git_repo.git.remote("prune", "origin")
         hash_after_pull = str(git_repo.head.commit)
         has_base_branch_update = hash_before_pull != hash_after_pull
         if has_base_branch_update is True:


### PR DESCRIPTION
`git pull` can exit with an error message similar to this:
```
fatal: cannot lock ref 'refs/heads/test/ttt': 'refs/heads/test' exists; cannot create 'refs/heads/test/ttt'
```

A situation like this can arise if the remote repository once contained a branch `test`. rcmt pulled the branch. Then the branch was deleted in the remote repository, but rcmt did not delete the branch locally.

The fix runs `git remote prune origin` after pulling the latest changes to get rid of any deleted branches.