### PR TITLE
fix: Continue execution if Task causes exception

### DIFF
--- a/rcmt/task.py
+++ b/rcmt/task.py
@@ -190,7 +190,11 @@ def read(path: str) -> Task:
     assert spec is not None
     new_module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = new_module
-    loader.exec_module(new_module)
+    try:
+        loader.exec_module(new_module)
+    except Exception as e:
+        raise RuntimeError(f"Import failed with {e.__class__.__name__}: {str(e)}")
+
     try:
         task = new_module.task  # type: ignore # because the content of module is not known
     except AttributeError:

--- a/tests/fixtures/test_rcmt/ExecuteTest/task_exception.py
+++ b/tests/fixtures/test_rcmt/ExecuteTest/task_exception.py
@@ -1,0 +1,7 @@
+from rcmt import Task
+from rcmt.action import Own
+
+d = {}
+
+with Task("unit-test-exception") as task:
+    task.add_action(Own(content=d["unknown"], target="test.txt"))

--- a/tests/fixtures/test_run/ReadTaskTest/test_read__code_exception/task.py
+++ b/tests/fixtures/test_run/ReadTaskTest/test_read__code_exception/task.py
@@ -1,0 +1,8 @@
+from rcmt import Task
+from rcmt.action import Own
+
+d = {}
+v = d["key"]
+
+with Task("unit-test") as task:
+    task.add_action(Own(content="unittest", target="test.txt"))

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -34,6 +34,17 @@ class ReadTaskTest(unittest.TestCase):
             "tests/fixtures/test_run/ReadTaskTest/test_read__backward_compatible_run_var/run.py"
         )
 
+    def test_read__code_exception(self):
+        with self.assertRaises(RuntimeError) as e:
+            read(
+                "tests/fixtures/test_run/ReadTaskTest/test_read__code_exception/task.py"
+            )
+
+        self.assertEqual(
+            "Import failed with KeyError: 'key'",
+            str(e.exception),
+        )
+
 
 class RunTest(unittest.TestCase):
     def test_branch__custom_name_not_altered(self):


### PR DESCRIPTION
rcmt stops execution when it loads a Task file and code in that file raises an exception.

This change catches any exception raised during the load of a Task file, continues execution and makes the process exit with an exit code > 0 at the end.