### PR TITLE
fix(gitlab): ignore archived project when listing open merge requests

### DIFF
--- a/rcmt/source/gitlab.py
+++ b/rcmt/source/gitlab.py
@@ -230,7 +230,7 @@ class Gitlab(Base):
             if project.archived is True:
                 log.debug(
                     "ignore project because it has been archived",
-                    repository=project.path_with_namespace,
+                    project=project.path_with_namespace,
                 )
                 continue
 

--- a/rcmt/source/gitlab.py
+++ b/rcmt/source/gitlab.py
@@ -227,6 +227,13 @@ class Gitlab(Base):
 
             seen_project_ids.append(mr.project_id)
             project = self.client.projects.get(id=mr.project_id)
+            if project.archived is True:
+                log.debug(
+                    "ignore project because it has been archived",
+                    repository=project.path_with_namespace,
+                )
+                continue
+
             repository = GitlabRepository(
                 project=project, token=self.client.private_token, url=self.url  # type: ignore
             )


### PR DESCRIPTION
Fixes #374 