### PR TITLE
fix: fix mypy not validating task files

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -21,6 +21,7 @@ header:
     - 'README'
     - '*.lock'
     - '**/*.txt'
+    - 'py.typed'
 
   comment: on-failure
 

--- a/docs/examples/custom_filter/task.py
+++ b/docs/examples/custom_filter/task.py
@@ -44,4 +44,4 @@ with Task(name="filter-example") as task:
     # Use the function.
     task.add_filter(filter_as_function)
     # Use a lambda function.
-    task.add_filter(lambda repo: repo.full_name == "github.com/wndhydrnt/rcmt")
+    task.add_filter(lambda ctx: ctx.repo.full_name == "github.com/wndhydrnt/rcmt")

--- a/rcmt/task.py
+++ b/rcmt/task.py
@@ -156,10 +156,10 @@ class Task:
         self.handlers_created: list[EventHandler] = []
         self.handlers_merged: list[EventHandler] = []
 
-    def __enter__(self):
+    def __enter__(self) -> "Task":
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         # Do not register if an exception occurred
         if exc_val is not None:
             return


### PR DESCRIPTION
Fixes errors like the following when running `mypy`:

```
task.py:1: error: Skipping analyzing "rcmt": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```

Add file "py.typed" as described in [PEP-561](https://peps.python.org/pep-0561/#packaging-type-information).