### PR TITLE
fix: validate command does not work with class-based Task definitions

### DIFF
--- a/rcmt/cli.py
+++ b/rcmt/cli.py
@@ -95,7 +95,7 @@ rcmt validate tasks/*.py
 
 @click.command(help=validate_help, short_help="Validate Task files")
 @click.argument("task_file", type=click.Path(), nargs=-1)
-def validate(task_file: tuple[str]):
+def validate(task_file: tuple[str, ...]):
     if rcmt.validate(task_file_paths=task_file) is False:
         exit(1)
 

--- a/rcmt/validate.py
+++ b/rcmt/validate.py
@@ -5,15 +5,16 @@
 from rcmt import task
 
 
-def validate(task_file_paths: tuple[str]) -> bool:
-    result: bool = False
+def validate(task_file_paths: tuple[str, ...]) -> bool:
+    result: bool = True
     for task_file_path in task_file_paths:
         try:
             task.read(task_file_path)
-            t = task.registry.tasks[-1]
-            print(f"✅ Task {t.name} in file {task_file_path} is valid")
         except Exception as e:
             print(f"❌ Task in file {task_file_path} is invalid: {str(e)}")
             result = False
+
+    for t in task.registry.tasks:
+        print(f"✅ Task '{t.name}' is valid")
 
     return result

--- a/tests/fixtures/test_validate/invalid/task_one.py
+++ b/tests/fixtures/test_validate/invalid/task_one.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 from rcmt import Context, Task, register_task
 
 

--- a/tests/fixtures/test_validate/invalid/task_one.py
+++ b/tests/fixtures/test_validate/invalid/task_one.py
@@ -1,0 +1,14 @@
+from rcmt import Context, Task, register_task
+
+
+class TaskOne(Task):
+    name = "task-one"
+
+    def filter(self, ctx: Context) -> bool:
+        return False
+
+    def apply(self, ctx: Context) -> None:
+        return None
+
+
+register_task(TaskOne())

--- a/tests/fixtures/test_validate/invalid/task_two.py
+++ b/tests/fixtures/test_validate/invalid/task_two.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 from rcmt import Context, Task, register_task
 
 

--- a/tests/fixtures/test_validate/invalid/task_two.py
+++ b/tests/fixtures/test_validate/invalid/task_two.py
@@ -1,0 +1,15 @@
+from rcmt import Context, Task, register_task
+
+
+class TaskTwo(Task):
+    # Invalid: Has the same name as the Task in task_one.py
+    name = "task-one"
+
+    def filter(self, ctx: Context) -> bool:
+        return False
+
+    def apply(self, ctx: Context) -> None:
+        return None
+
+
+register_task(TaskTwo())

--- a/tests/fixtures/test_validate/valid/task_one.py
+++ b/tests/fixtures/test_validate/valid/task_one.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 from rcmt import Context, Task, register_task
 
 

--- a/tests/fixtures/test_validate/valid/task_one.py
+++ b/tests/fixtures/test_validate/valid/task_one.py
@@ -1,0 +1,14 @@
+from rcmt import Context, Task, register_task
+
+
+class TaskOne(Task):
+    name = "task-one"
+
+    def filter(self, ctx: Context) -> bool:
+        return False
+
+    def apply(self, ctx: Context) -> None:
+        return None
+
+
+register_task(TaskOne())

--- a/tests/fixtures/test_validate/valid/task_two.py
+++ b/tests/fixtures/test_validate/valid/task_two.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 from rcmt import Context, Task, register_task
 
 

--- a/tests/fixtures/test_validate/valid/task_two.py
+++ b/tests/fixtures/test_validate/valid/task_two.py
@@ -1,0 +1,14 @@
+from rcmt import Context, Task, register_task
+
+
+class TaskTwo(Task):
+    name = "task-two"
+
+    def filter(self, ctx: Context) -> bool:
+        return False
+
+    def apply(self, ctx: Context) -> None:
+        return None
+
+
+register_task(TaskTwo())

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,27 @@
+import unittest
+
+from rcmt.task import registry
+from rcmt.validate import validate
+
+
+class ValidateTest(unittest.TestCase):
+    def setUp(self):
+        registry.tasks = []
+
+    def test_validate__valid(self):
+        paths = (
+            "tests/fixtures/test_validate/valid/task_one.py",
+            "tests/fixtures/test_validate/valid/task_two.py",
+        )
+        result = validate(task_file_paths=paths)
+
+        self.assertTrue(result, "Should return True if all Tasks are valid")
+
+    def test_validate__invalid(self):
+        paths = (
+            "tests/fixtures/test_validate/invalid/task_one.py",
+            "tests/fixtures/test_validate/invalid/task_two.py",
+        )
+        result = validate(task_file_paths=paths)
+
+        self.assertFalse(result, "Should return False if validation failed")

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 import unittest
 
 from rcmt.task import registry


### PR DESCRIPTION
Also fixes type hint of `validate()` function.