### PR TITLE
fix(git): set branch name when rebasing from remote

### DIFF
--- a/rcmt/git.py
+++ b/rcmt/git.py
@@ -175,7 +175,9 @@ class Git:
             # `strategy_option="theirs"` to always prefer changes from the remote.
             # Commits by someone else will be preserved with this strategy and there
             # will be no conflict.
-            git_repo.remotes["origin"].pull(rebase=True, strategy_option="theirs")
+            git_repo.remotes["origin"].pull(
+                self.branch_name, rebase=True, strategy_option="theirs"
+            )
 
         merge_base = git_repo.git.merge_base(repo.base_branch, self.branch_name)
         if force_rebase is False:


### PR DESCRIPTION
Without this fix, pulling changes from the remote of a cloned repository fails with the following error:

```
Cmd('git') failed due to: exit code(1)
  cmdline: git pull -v --rebase --strategy-option=theirs -- origin
```