### PR TITLE
fix(verify): apply task in checkout directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ htmlcov
 dist/
 hack/rcmt.sqlite
 site/
+.rcmt/

--- a/rcmt/verify.py
+++ b/rcmt/verify.py
@@ -7,7 +7,7 @@ from typing import Optional, TextIO
 import structlog
 
 import rcmt.git
-from rcmt import task
+from rcmt import fs, task
 from rcmt.context import Context
 from rcmt.rcmt import Options
 from rcmt.source import Repository
@@ -54,10 +54,12 @@ def execute(directory: str, opts: Options, out: TextIO, repo_name: str) -> None:
         print("🏗️  Preparing git clone", file=out)
         checkout_dir, has_conflict = gitc.prepare(force_rebase=False, repo=repository)
         print("🚜 Applying Task", file=out)
-        t.apply(ctx=ctx)
+        with fs.in_checkout_dir(checkout_dir):
+            t.apply(ctx=ctx)
+
         if gitc.has_changes_local(repo_dir=checkout_dir):
             print(
                 f"😍 Actions modified files - view changes in {checkout_dir}", file=out
             )
         else:
-            print("🤔 No changes after applying Actions", file=out)
+            print("⚠️  No changes after applying Actions", file=out)

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,7 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
+import tempfile
 import unittest
 import unittest.mock
 
@@ -43,8 +43,8 @@ class ExecuteTest(unittest.TestCase):
         registry.tasks.append(task)
 
         git_mock = unittest.mock.Mock(spec=Git)
-        checkout_dir = "/tmp/repository/github.com/wndhydrnt/rcmt"
-        git_mock.prepare.return_value = (checkout_dir, False)
+        checkout_dir = tempfile.TemporaryDirectory()
+        git_mock.prepare.return_value = (checkout_dir.name, False)
         git_class_mock.return_value = git_mock
 
         with open("/dev/null", "w") as f:
@@ -61,3 +61,4 @@ class ExecuteTest(unittest.TestCase):
         self.assertEqual(repository_mock, ctx.repo)
         task_read_mock.assert_called_with("/tmp/run.py")
         task.apply.assert_called_once_with(ctx=ctx)
+        checkout_dir.cleanup()


### PR DESCRIPTION
Without this change, the `apply()` method of a `Task` gets executed in the current working directory instead of the checkout directory of the repository to validate.