### PR TITLE
feat(action): let actions "own" and "seed" create a directory if it does not exist

### DIFF
--- a/rcmt/action.py
+++ b/rcmt/action.py
@@ -44,6 +44,9 @@ def own(ctx: Context, content: str, target: str) -> None:
 
     It overwrites the content of the file with the value of `content`.
 
+    If `target` contains one or more directories and the directories do not exist, they
+    will be created recursively.
+
     Args:
         ctx: The current context.
         content: Content of the file to write.
@@ -72,6 +75,9 @@ def seed(ctx: Context, content: str, target: str) -> None:
     """Seed ensures that a file in a repository is present.
 
     It does not modify the file again if the file is present in a repository.
+
+    If `target` contains one or more directories and the directories do not exist, they
+    will be created recursively.
 
     Args:
         ctx: The current context.

--- a/rcmt/action.py
+++ b/rcmt/action.py
@@ -60,6 +60,10 @@ def own(ctx: Context, content: str, target: str) -> None:
                 own(content=content, target=".flake8")
         ```
     """
+    dir = os.path.dirname(target)
+    if dir != "" and os.path.exists(dir) is False:
+        os.makedirs(name=dir)
+
     with open(target, "w+") as f:
         f.write(string.Template(content).substitute(ctx.template_data))
 

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -161,6 +161,18 @@ class OwnTest(unittest.TestCase):
 
             self.assertEqual("unit-test", content)
 
+    def test_apply__create_directory(self):
+        ctx = context.Context(repo=unittest.mock.Mock(spec=source.Repository))
+        with tempfile.TemporaryDirectory() as d:
+            test_file_path = "first/second/test.txt"
+            with fs.in_checkout_dir(d):
+                own(ctx=ctx, content="unit-test", target=test_file_path)
+
+            with open(os.path.join(d, test_file_path), "r") as test_file:
+                content = test_file.read()
+
+            self.assertEqual("unit-test", content)
+
 
 class SeedTest(unittest.TestCase):
     def test_apply_seed_file(self):
@@ -188,6 +200,18 @@ class SeedTest(unittest.TestCase):
                 content = test_file.read()
 
             self.assertEqual("abc\n", content)
+
+    def test_apply__create_directory(self):
+        ctx = context.Context(repo=unittest.mock.Mock(spec=source.Repository))
+        with tempfile.TemporaryDirectory() as d:
+            test_file_path = "first/second/test.txt"
+            with fs.in_checkout_dir(d):
+                seed(ctx=ctx, content="unit-test", target=test_file_path)
+
+            with open(os.path.join(d, test_file_path), "r") as test_file:
+                content = test_file.read()
+
+            self.assertEqual("unit-test", content)
 
 
 class ReplaceInLineTest(unittest.TestCase):


### PR DESCRIPTION
If `target` points to a file with sub-directories, the sub-directories will be created recursively if they do not exist.