### PR TITLE
fix(task): do not error if a Task class that gets extended is not registered

### DIFF
--- a/tests/fixtures/test_task/test_read__not_registered_ignore_extended_class/task.py
+++ b/tests/fixtures/test_task/test_read__not_registered_ignore_extended_class/task.py
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from rcmt import Task, register_task
+
+
+class Base(Task):
+    name = "Base"
+
+
+class Test(Base):
+    name = "Test"
+
+
+register_task(Test())

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -39,6 +39,13 @@ class ReadTaskTest(unittest.TestCase):
             str(e.exception),
         )
 
+    def test_read__ignore_extended_class(self):
+        read(
+            "tests/fixtures/test_task/test_read__not_registered_ignore_extended_class/task.py"
+        )
+
+        self.assertEqual(1, len(registry.tasks), "Should register one task")
+
 
 class TaskWrapperTest(unittest.TestCase):
     def test_branch__custom_name_not_altered(self):


### PR DESCRIPTION
Fixes the error

```
"File 'task.py' defines Task 'Base' but does not register it - use rcmt.register_task(Base())"
```

for `task.py`:

```python
from rcmt import Task, register_task


class Base(Task):
    name = "Base"


class Test(Base):
    name = "Test"


register_task(Test())
```