### PR TITLE
feat(rcmt): add option to make rcmt create a pull request but never update it on next runs

### DIFF
--- a/rcmt/rcmt.py
+++ b/rcmt/rcmt.py
@@ -110,6 +110,9 @@ class RepoRun:
             )
             return RunResult.PR_MERGED_BEFORE
 
+        if pr_identifier is not None and matcher.create_only is True:
+            return RunResult.PR_OPEN
+
         force_rebase = self._has_rebase_checked(pr=pr_identifier, repo=repo)
         try:
             work_dir, has_conflict = self.git.prepare(

--- a/rcmt/task.py
+++ b/rcmt/task.py
@@ -40,6 +40,8 @@ class Task:
                       requests at the same time. Defaults to ``None`` which means no
                       limit.
         commit_msg: Message to use when committing changes via git.
+        create_only: If `True`, create the pull request but do not rebase and push
+                     updates on subsequent runs of rcmt. Defaults to `False`.
         delete_branch_after_merge: If `True`, rcmt will delete the branch after it has
                                    been merged. Defaults to `True`.
         enabled: If `False`, disables the task. Handy if a task needs to be stopped
@@ -85,6 +87,7 @@ class Task:
     branch_name: str = ""
     change_limit: Optional[int] = None
     commit_msg: str = "Applied actions"
+    create_only: bool = False
     delete_branch_after_merge: bool = True
     enabled: bool = True
     merge_once: bool = False

--- a/rcmt/task.py
+++ b/rcmt/task.py
@@ -41,7 +41,10 @@ class Task:
                       limit.
         commit_msg: Message to use when committing changes via git.
         create_only: If `True`, create the pull request but do not rebase and push
-                     updates on subsequent runs of rcmt. Defaults to `False`.
+                     updates on subsequent runs of rcmt. Allows users to modify the pull
+                     request without triggering the override detection. Setting
+                     `auto_merge` will have no effect if this parameter is set to
+                     `True`. Defaults to `False`.
         delete_branch_after_merge: If `True`, rcmt will delete the branch after it has
                                    been merged. Defaults to `True`.
         enabled: If `False`, disables the task. Handy if a task needs to be stopped


### PR DESCRIPTION
Add parameter `create_only` to `Task`.

If `True`, rcmt will only create a pull request but not rebase it if the default branch contains changes. This keeps a pull request stable and allows users to modify it without triggering the foreign commit detection.