### PR TITLE
chore: fix builds of readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,11 +5,11 @@ build:
   tools:
     python: "3.10"
   jobs:
+    # https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-poetry
     post_create_environment:
       - pip install poetry
-      - poetry config virtualenvs.create false
     post_install:
-      - poetry install --with docs
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
 
 mkdocs:
   configuration: mkdocs.yml


### PR DESCRIPTION
A week or two ago, ReadTheDocs changed the way dependencies need to be installed when using Poetry.

https://github.com/readthedocs/readthedocs.org/pull/11152/